### PR TITLE
fix use of `NTuple`

### DIFF
--- a/src/maps/ComposedMaps.jl
+++ b/src/maps/ComposedMaps.jl
@@ -97,7 +97,7 @@ end
 
 # TODO
   struct ComposedCircleMap{M<:AbstractMarkovMap,D<:Domain,R<:Domain} <: AbstractMarkovMap{D,R}
-    maps::NTuple{M}
+    maps::Tuple{Vararg{M}}
     domain::D
     rangedomain::R
     end


### PR DESCRIPTION
This causes an error on newer Julia versions; should now work on all 1.x.